### PR TITLE
fix: GET /votes/{voteId}/comments 댓글조회 API의 반환값에 commentId 추가

### DIFF
--- a/src/main/java/com/valanse/valanse/domain/enums/MbtiTf.java
+++ b/src/main/java/com/valanse/valanse/domain/enums/MbtiTf.java
@@ -3,4 +3,3 @@ package com.valanse.valanse.domain.enums;
 public enum MbtiTf {
     T, F
 }
-

--- a/src/main/java/com/valanse/valanse/dto/Comment/CommentResponseDto.java
+++ b/src/main/java/com/valanse/valanse/dto/Comment/CommentResponseDto.java
@@ -10,6 +10,7 @@ import com.querydsl.core.annotations.QueryProjection;
 @Getter
 @Builder
 public class CommentResponseDto {
+    private Long commentId;
     private Long voteId;
     private String nickname;
     private LocalDateTime createdAt;
@@ -20,9 +21,10 @@ public class CommentResponseDto {
     private String label;
 
     @QueryProjection
-    public CommentResponseDto(Long voteId, String nickname, LocalDateTime createdAt,
+    public CommentResponseDto(Long commentId, Long voteId, String nickname, LocalDateTime createdAt,
                               String content, Integer likeCount, Integer replyCount,
                               LocalDateTime deletedAt, String label) {
+        this.commentId = commentId;
         this.voteId = voteId;
         this.nickname = nickname;
         this.createdAt = createdAt;

--- a/src/main/java/com/valanse/valanse/repository/CommentRepositoryCustom/CommentRepositoryImpl.java
+++ b/src/main/java/com/valanse/valanse/repository/CommentRepositoryCustom/CommentRepositoryImpl.java
@@ -31,6 +31,7 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
 
         List<CommentResponseDto> result = queryFactory
                 .select(new QCommentResponseDto(
+                        comment.id,
                         vote.id,
                         member.profile.nickname,
                         comment.createdAt,
@@ -39,10 +40,6 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
                         comment.replyCount,
                         comment.deletedAt,
                         voteOption.label.stringValue()
-//                        new CaseBuilder()
-//                                .when(voteOption.isNotNull())
-//                                .then(voteOption.label.stringValue())
-//                                .otherwise(constant("NONE"))
                 ))
                 .from(comment)
                 .join(comment.member, member)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new field to comment responses that displays the comment ID in relevant views.

* **Style**
  * Minor formatting improvements for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->