### PR TITLE
날짜fix: 형식 수정

### DIFF
--- a/src/main/java/com/valanse/valanse/dto/Vote/VoteListResponse.java
+++ b/src/main/java/com/valanse/valanse/dto/Vote/VoteListResponse.java
@@ -9,6 +9,9 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+
 
 @Data
 @NoArgsConstructor
@@ -28,6 +31,7 @@ public class VoteListResponse {
         private String category; // ENUM 이름을 String으로 반환
         private Long member_id;
         private String nickname;
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
         private LocalDateTime created_at;
         private Integer total_vote_count;
         private Integer total_comment_count; // 댓글 그룹의 총 댓글 수

--- a/src/main/java/com/valanse/valanse/dto/Vote/VoteResponseDto.java
+++ b/src/main/java/com/valanse/valanse/dto/Vote/VoteResponseDto.java
@@ -20,7 +20,7 @@ public class VoteResponseDto {
         this.title = vote.getTitle();
         this.category = vote.getCategory().name(); // enum to string
         this.totalVoteCount = vote.getTotalVoteCount();
-        this.createdAt = vote.getCreatedAt().toString();
+        this.createdAt = vote.getCreatedAt().toLocalDate().toString();
         this.options = vote.getVoteOptions()
                 .stream()
                 .map(option -> option.getContent())  //  VoteOption에서 content 추출


### PR DESCRIPTION
votes 를
yyyy-mm-dd 로 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date formatting for vote creation dates to consistently display only the date (yyyy-MM-dd) without the time component in API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->