### PR TITLE
feat: develop.valanse.kr CORS 설정 추가

### DIFF
--- a/src/main/java/com/valanse/valanse/common/config/SecurityConfig.java
+++ b/src/main/java/com/valanse/valanse/common/config/SecurityConfig.java
@@ -77,7 +77,9 @@ public class SecurityConfig {
         configuration.setAllowedOrigins(Arrays.asList(
                 "http://localhost:3000",
                 "https://test-front-security.netlify.app",
-                "https://valan-se-web.vercel.app",
+                "https://valan-se-web.vercel.app", // 예전 도메인 네임
+                "https://valanse.kr", // 새 도메인 네임
+                "https://develop.valanse.kr", // 새 프론트 개발서버 도메인
                 "https://backendbase.store",
                 "http://backendbase.store:8080",   // 운영 환경 HTTP
                 "http://backendbase.store:8081",   // 개발 환경 HTTP ← 이거 추가!


### PR DESCRIPTION
## 변경 사항
- SecurityConfig에 `develop.valanse.kr` CORS 허용 추가

## 추가 작업 (서버 측)
- application.yml에 `dev-server` 프로필 추가 완료
- docker-compose.yml에 `valanse-dev-server` 컨테이너 추가 완료 (8082 포트)
- 카카오 개발자 콘솔에 redirect URI 등록: `https://develop.valanse.kr/oauth/kakao/redirect`