### PR TITLE
Fix/#125 service code refactor

### DIFF
--- a/src/main/java/com/valanse/valanse/repository/VoteRepositoryImpl.java
+++ b/src/main/java/com/valanse/valanse/repository/VoteRepositoryImpl.java
@@ -77,7 +77,6 @@ public class VoteRepositoryImpl implements VoteRepositoryCustom {
                 queryFactory
                         .selectFrom(vote)
                         .leftJoin(vote.commentGroup, commentGroup)
-                        .fetchJoin()
                         .orderBy(
                         vote.totalVoteCount
                                 .add(commentGroup.totalCommentCount.coalesce(0))
@@ -93,7 +92,6 @@ public class VoteRepositoryImpl implements VoteRepositoryCustom {
                 queryFactory
                         .selectFrom(vote)
                         .leftJoin(vote.commentGroup, commentGroup)
-                        .fetchJoin()
                         .where(
                                 // 기간 내 댓글 존재
                                 JPAExpressions

--- a/src/main/java/com/valanse/valanse/repository/VoteRepositoryImpl.java
+++ b/src/main/java/com/valanse/valanse/repository/VoteRepositoryImpl.java
@@ -2,7 +2,9 @@ package com.valanse.valanse.repository;
 
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Predicate;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.valanse.valanse.domain.QCommentGroup;
 import com.valanse.valanse.domain.QVote;
 import com.valanse.valanse.domain.Vote;
 import com.valanse.valanse.domain.enums.VoteCategory;
@@ -13,6 +15,11 @@ import org.springframework.stereotype.Repository;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+
+import static com.valanse.valanse.domain.QComment.comment;
+import static com.valanse.valanse.domain.QVoteOption.voteOption;
+import static com.valanse.valanse.domain.mapping.QMemberVoteOption.memberVoteOption;
 
 @Repository
 @RequiredArgsConstructor
@@ -20,6 +27,7 @@ public class VoteRepositoryImpl implements VoteRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
     private final QVote vote = QVote.vote;
+    private final QCommentGroup commentGroup = QCommentGroup.commentGroup;
 
     @Override
     public List<Vote> findVotesByCursor(String category, String sort, String cursor, int size) {
@@ -62,4 +70,62 @@ public class VoteRepositoryImpl implements VoteRepositoryCustom {
                 .limit(size + 1) // 다음 페이지 존재 여부 확인
                 .fetch();
     }
+
+    @Override
+    public Optional<Vote> findHotIssueVote() {
+        return Optional.ofNullable(
+                queryFactory
+                        .selectFrom(vote)
+                        .leftJoin(vote.commentGroup, commentGroup)
+                        .fetchJoin()
+                        .orderBy(
+                        vote.totalVoteCount
+                                .add(commentGroup.totalCommentCount.coalesce(0))
+                                .desc(),
+                        vote.createdAt.desc()  // 점수 같을 때 최신순
+                        )
+                        .fetchFirst());
+    }
+
+    @Override
+    public Optional<Vote> findTrendingVote(LocalDateTime from, LocalDateTime to) {
+        return Optional.ofNullable(
+                queryFactory
+                        .selectFrom(vote)
+                        .leftJoin(vote.commentGroup, commentGroup)
+                        .fetchJoin()
+                        .where(
+                                // 기간 내 댓글 존재
+                                JPAExpressions
+                                        .selectOne()
+                                        .from(comment)
+                                        .where(
+                                                comment.commentGroup.eq(commentGroup),
+                                                comment.createdAt.between(from, to),
+                                                comment.deletedAt.isNull()
+                                        )
+                                        .exists()
+                                        .or(
+                                                // 기간 내 투표 존재
+                                                JPAExpressions
+                                                        .selectOne()
+                                                        .from(memberVoteOption)
+                                                        .join(memberVoteOption.voteOption, voteOption)
+                                                        .where(
+                                                                voteOption.vote.eq(vote),
+                                                                memberVoteOption.createdAt.between(from, to)
+                                                        )
+                                                        .exists()
+                                        )
+                        )
+                        .orderBy(
+                                vote.totalVoteCount
+                                        .add(commentGroup.totalCommentCount.coalesce(0))
+                                        .desc(),
+                                vote.createdAt.desc()  // 점수 같을 때 최신순
+                        )
+                        .fetchFirst());
+
+    }
+
 }

--- a/src/main/java/com/valanse/valanse/repository/VotesCheckRepositoryCustom/VoteRepositoryCustom.java
+++ b/src/main/java/com/valanse/valanse/repository/VotesCheckRepositoryCustom/VoteRepositoryCustom.java
@@ -2,8 +2,12 @@ package com.valanse.valanse.repository.VotesCheckRepositoryCustom;
 
 import com.valanse.valanse.domain.Vote;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface VoteRepositoryCustom {
     List<Vote> findVotesByCursor(String category, String sort, String cursor, int size);
+    Optional<Vote> findHotIssueVote();
+    Optional<Vote> findTrendingVote(LocalDateTime from, LocalDateTime to);
 }

--- a/src/main/java/com/valanse/valanse/service/VoteService/VoteServiceImpl.java
+++ b/src/main/java/com/valanse/valanse/service/VoteService/VoteServiceImpl.java
@@ -88,7 +88,6 @@ public class VoteServiceImpl implements VoteService {
 
     //여기서부터 영서 코드
     @Override
-//    @Transactional
     public HotIssueVoteResponse getHotIssueVote() { // 파라미터 없음
         // 0. 고정 게시물이 있다면 반환.
         Optional<Vote> pinnedHot = voteRepository.findByPinType(PinType.HOT);

--- a/src/main/java/com/valanse/valanse/service/VoteService/VoteServiceImpl.java
+++ b/src/main/java/com/valanse/valanse/service/VoteService/VoteServiceImpl.java
@@ -118,7 +118,6 @@ public class VoteServiceImpl implements VoteService {
 
     // 인기 급상승 토픽
     @Override
-    @Transactional
     public HotIssueVoteResponse getTrendingVote() {
        // 0. 고정 게시물이 있다면 반환.
         Optional<Vote> pinnedTrending = voteRepository.findByPinType(PinType.TRENDING);

--- a/src/main/java/com/valanse/valanse/service/VoteService/VoteServiceImpl.java
+++ b/src/main/java/com/valanse/valanse/service/VoteService/VoteServiceImpl.java
@@ -178,11 +178,11 @@ public class VoteServiceImpl implements VoteService {
 
             if (oldVoteOption.getId().equals(voteOptionId)) {
                 // 3-1. 동일한 선택지를 다시 클릭한 경우: 투표 취소
-                // member_vote_option에서 해당 기록을 삭제 [cite: image_0268de.png]
+                // member_vote_option에서 해당 기록을 삭제
                 memberVoteOptionRepository.delete(oldMemberVoteOption);
-                // 기존 선택지의 투표 수 감소 [cite: image_0268de.png]
+                // 기존 선택지의 투표 수 감소
                 oldVoteOption.setVoteCount(oldVoteOption.getVoteCount() - 1);
-                // 전체 투표 수 감소 [cite: image_0268de.png]
+                // 전체 투표 수 감소a
                 vote.setTotalVoteCount(vote.getTotalVoteCount() - 1);
 
                 isVoted = false; // 투표가 취소되었으므로 false

--- a/src/main/java/com/valanse/valanse/service/VoteService/VoteServiceImpl.java
+++ b/src/main/java/com/valanse/valanse/service/VoteService/VoteServiceImpl.java
@@ -88,7 +88,7 @@ public class VoteServiceImpl implements VoteService {
 
     //여기서부터 영서 코드
     @Override
-    @Transactional
+//    @Transactional
     public HotIssueVoteResponse getHotIssueVote() { // 파라미터 없음
         // 0. 고정 게시물이 있다면 반환.
         Optional<Vote> pinnedHot = voteRepository.findByPinType(PinType.HOT);
@@ -101,24 +101,14 @@ public class VoteServiceImpl implements VoteService {
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime yesterdayStart = now.minusDays(1).withHour(0).withMinute(0).withSecond(0);
 
-        // 1. 먼저 모든 투표의 반응성 점수를 업데이트 (실시간 계산)
-        List<Vote> allVotes = voteRepository.findAll();
-        for(Vote vote : allVotes) {
-            vote.updateReactivityScore(); // Vote 엔티티에 추가한 메서드
-            voteRepository.save(vote);
-        }
-
-        // 2. 작일 동안 반응성이 가장 높은 투표 조회 시도
-        Optional<Vote> yesterdayHotIssue = voteRepository
-                .findTopByCreatedAtBetweenOrderByReactivityScoreDescCreatedAtDesc(yesterdayStart, now);
-
+        //  작일 동안 반응성이 가장 높은 투표 조회 시도
+        Optional<Vote> yesterdayHotIssue = voteRepository.findTrendingVote(yesterdayStart, now);
         Vote hotIssueVote;
         if (yesterdayHotIssue.isPresent()) {
             // 작일 반응성 데이터가 있는 경우
             hotIssueVote = yesterdayHotIssue.get();
         } else {
-            // 작일 반응성 데이터가 없는 경우 → 전체 누적 반응성 기준 조회
-            hotIssueVote = voteRepository.findTopByOrderByReactivityScoreDescCreatedAtDesc()
+            hotIssueVote = voteRepository.findHotIssueVote()
                     .orElseThrow(() -> new ApiException("핫이슈 투표를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
         }
 
@@ -140,19 +130,13 @@ public class VoteServiceImpl implements VoteService {
 
         }
 
-       // 7일 이전 시간 계산
-       LocalDateTime sevenDaysAgo = LocalDateTime.now().minusDays(7);
+        // 7일 이전 시간 계산
+        LocalDateTime sevenDaysAgo = LocalDateTime.now().minusDays(7);
+        LocalDateTime now = LocalDateTime.now();
 
-       // 1. 모든 투표의 반응성 점수 업데이트
-        List<Vote> allVotes = voteRepository.findAll();
-        for(Vote vote : allVotes) {
-            vote.updateReactivityScore();
-            voteRepository.save(vote);
-        }
-
-        // 2. 최근 7일 내 반응성이 가장 높은 투표 조회
+        // 최근 7일 내 반응성이 가장 높은 투표 조회
         Optional<Vote> recentTrendingVote = voteRepository
-                .findTopByCreatedAtBetweenOrderByReactivityScoreDescCreatedAtDesc(sevenDaysAgo, LocalDateTime.now());
+                .findTrendingVote(sevenDaysAgo, now);
 
         Vote trendingVote;
         if (recentTrendingVote.isPresent()) {
@@ -160,7 +144,7 @@ public class VoteServiceImpl implements VoteService {
             trendingVote = recentTrendingVote.get();
         } else {
             // 7일 내 데이터가 없는 경우 - 이전 데이터 유지 (전체 기간에서 가장 높은 반응성)
-            trendingVote = voteRepository.findTopByOrderByReactivityScoreDescCreatedAtDesc()
+            trendingVote = voteRepository.findHotIssueVote()
                     .orElseThrow(() -> new ApiException("인기 급상승 투표를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
         }
 

--- a/src/main/java/com/valanse/valanse/service/VoteService/VoteServiceImpl.java
+++ b/src/main/java/com/valanse/valanse/service/VoteService/VoteServiceImpl.java
@@ -282,16 +282,8 @@ public class VoteServiceImpl implements VoteService {
                     SecurityContextHolder.getContext().getAuthentication().getName() != null &&
                     !SecurityContextHolder.getContext().getAuthentication().getName().equals("anonymousUser")) {
                 currentUserId = Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
-                // --- 디버깅 로그 추가 시작 ---
-                System.out.println("DEBUG: Authenticated user ID: " + currentUserId);
-                // --- 디버깅 로그 추가 끝 ---
-            } else {
-                // --- 디버깅 로그 추가 시작 ---
-                System.out.println("DEBUG: User is not authenticated or is anonymous.");
-                // --- 디버깅 로그 추가 끝 ---
             }
         } catch (NumberFormatException e) {
-            System.out.println("DEBUG: Error parsing user ID from SecurityContext: " + e.getMessage());
             currentUserId = null;
         }
 

--- a/src/main/java/com/valanse/valanse/service/VoteService/VoteServiceImpl.java
+++ b/src/main/java/com/valanse/valanse/service/VoteService/VoteServiceImpl.java
@@ -165,7 +165,6 @@ public class VoteServiceImpl implements VoteService {
                 .orElseThrow(() -> new ApiException("투표 선택지가 존재하지 않습니다.", HttpStatus.NOT_FOUND));
 
         // 2. 사용자가 이 투표에 대해 이전에 투표한 선택지가 있는지 확인합니다.
-        // ERD의 member_vote_option 테이블을 활용 [cite: image_02691a.jpg]
         Optional<MemberVoteOption> existingVote = memberVoteOptionRepository.findByMemberIdAndVoteId(userId, voteId);
 
         boolean isVoted; // 최종적으로 투표가 되어 있는지 여부 (응답 DTO에 사용)

--- a/src/test/java/com/valanse/valanse/controller/VoteControllerTest.java
+++ b/src/test/java/com/valanse/valanse/controller/VoteControllerTest.java
@@ -5,8 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.valanse.valanse.domain.*;
 import com.valanse.valanse.domain.enums.*;
 import com.valanse.valanse.repository.CommentGroupRepository;
-import com.valanse.valanse.repository.MemberProfileRepository; //
-import com.valanse.valanse.repository.MemberRepository; //
+import com.valanse.valanse.repository.MemberProfileRepository;
+import com.valanse.valanse.repository.MemberRepository;
 import com.valanse.valanse.repository.VoteRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -21,240 +21,143 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.Arrays;
-import java.util.List;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest // Spring Boot 테스트 환경 로드
-@AutoConfigureMockMvc // MockMvc 자동 구성
-@ActiveProfiles("test") // application-test.yml 프로파일 활성화
-@Transactional // 각 테스트 메서드가 끝날 때 트랜잭션 롤백
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
 public class VoteControllerTest {
 
-    @Autowired
-    private MockMvc mockMvc; // HTTP 요청을 시뮬레이션하는 데 사용
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private VoteRepository voteRepository;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private MemberProfileRepository memberProfileRepository;
+    @Autowired private CommentGroupRepository commentGroupRepository;
 
-    @Autowired
-    private ObjectMapper objectMapper; // JSON 직렬화/역직렬화를 위한 유틸리티
-
-    @Autowired
-    private VoteRepository voteRepository;
-
-    @Autowired
-    private MemberRepository memberRepository; // Member 저장을 위해 필요
-
-    @Autowired
-    private MemberProfileRepository memberProfileRepository; // MemberProfile 저장을 위해 필요
-
-    @Autowired
-    private CommentGroupRepository commentGroupRepository;
-
-    @BeforeEach // 각 테스트 메서드 실행 전에 실행
+    @BeforeEach
     void setUp() {
-        // 데이터 클린업 (Transactional 어노테이션으로 롤백되므로 필수는 아니지만 명시적으로 초기화)
         voteRepository.deleteAll();
         commentGroupRepository.deleteAll();
         memberProfileRepository.deleteAll();
         memberRepository.deleteAll();
 
-        // 핫이슈 투표 생성 시 필요한 멤버 및 프로필 데이터 생성
-        Member member1 = Member.builder() //
-                .socialId("kakao123")
-                .email("test1@example.com")
-                .name("테스터1")
+        Member member1 = Member.builder()
+                .socialId("kakao123").email("test1@example.com").name("테스터1")
                 .profile_image_url("http://image.com/test1.jpg")
-                .kakaoAccessToken("token1")
-                .kakaoRefreshToken("refresh1")
-                .build();
-        memberRepository.save(member1); //
+                .kakaoAccessToken("token1").kakaoRefreshToken("refresh1").build();
+        memberRepository.save(member1);
 
-        MemberProfile profile1 = MemberProfile.builder() //
-                .member(member1)
-                .nickname("테스터1닉네임")
-                .gender(Gender.MALE) //
-                .age(Age.TWENTY) //
-                .mbti("ENFP")
-                .build();
-        memberProfileRepository.save(profile1); //
+        memberProfileRepository.save(MemberProfile.builder()
+                .member(member1).nickname("테스터1닉네임")
+                .gender(Gender.MALE).age(Age.TWENTY).mbti("ENFP").build());
 
-        // 투표 생성 - 핫이슈 (가장 높은 반응성)
-        Vote hotIssueVote = Vote.builder() //
-                .category(VoteCategory.FOOD) // <-- 88번 줄: VoteCategory enum 값을 올바르게 할당
-                .title("오늘의 점심 선택은?")
-                .totalVoteCount(100)
-                .reactivityScore(110) // 투표 100 + 댓글 10 = 반응성 110
-                .reactivityUpdatedAt(LocalDateTime.now()) // 현재 시간으로 설정
-                .member(member1)//
-                .pinType(PinType.NONE)
-                .build();
+        Vote hotIssueVote = Vote.builder()
+                .category(VoteCategory.FOOD).title("오늘의 점심 선택은?")
+                .totalVoteCount(100).reactivityScore(110)
+                .reactivityUpdatedAt(LocalDateTime.now())
+                .member(member1).pinType(PinType.NONE).build();
         voteRepository.save(hotIssueVote);
 
-        // CommentGroup 생성 (댓글 10개)
-        CommentGroup commentGroup = CommentGroup.builder()
-                .vote(hotIssueVote)
-                .totalCommentCount(10)
-                .build();
-        commentGroupRepository.save(commentGroup);
+        commentGroupRepository.save(CommentGroup.builder()
+                .vote(hotIssueVote).totalCommentCount(10).build());
 
-
-        // 핫이슈 투표 옵션들
-        VoteOption optionA = VoteOption.builder() //
-                .vote(hotIssueVote)
-                .content("A. 맵고 얼큰한 라면")
-                .voteCount(60)
-                .label(VoteLabel.A) //
-                .build();
-        VoteOption optionB = VoteOption.builder() //
-                .vote(hotIssueVote)
-                .content("B. 부드러운 파스타")
-                .voteCount(40)
-                .label(VoteLabel.B) //
-                .build();
+        VoteOption optionA = VoteOption.builder().vote(hotIssueVote)
+                .content("A. 맵고 얼큰한 라면").voteCount(60).label(VoteLabel.A).build();
+        VoteOption optionB = VoteOption.builder().vote(hotIssueVote)
+                .content("B. 부드러운 파스타").voteCount(40).label(VoteLabel.B).build();
         hotIssueVote.getVoteOptions().addAll(Arrays.asList(optionA, optionB));
-        voteRepository.save(hotIssueVote); // 옵션 추가 후 다시 저장
+        voteRepository.save(hotIssueVote);
 
-        // 다른 투표 생성 (반응성이 더 낮은 투표)
-        Member member2 = Member.builder() //
-                .socialId("kakao456")
-                .email("test2@example.com")
-                .name("테스터2")
+        Member member2 = Member.builder()
+                .socialId("kakao456").email("test2@example.com").name("테스터2")
                 .profile_image_url("http://image.com/test2.jpg")
-                .kakaoAccessToken("token2")
-                .kakaoRefreshToken("refresh2")
-                .build();
-        memberRepository.save(member2); //
+                .kakaoAccessToken("token2").kakaoRefreshToken("refresh2").build();
+        memberRepository.save(member2);
 
-        MemberProfile profile2 = MemberProfile.builder() //
-                .member(member2)
-                .nickname("테스터2닉네임")
-                .gender(Gender.FEMALE) //
-                .age(Age.THIRTY) //
-                .mbti("ISTJ")
-                .build();
-        memberProfileRepository.save(profile2); //
+        memberProfileRepository.save(MemberProfile.builder()
+                .member(member2).nickname("테스터2닉네임")
+                .gender(Gender.FEMALE).age(Age.THIRTY).mbti("ISTJ").build());
 
-        // 다른 투표 생성 (반응성이 더 낮은 투표)
-        Vote otherVote = Vote.builder() //
-                .category(VoteCategory.LOVE) // <-- 133번 줄: VoteCategory enum 값을 올바르게 할당
-                .title("연애 밸런스 게임")
-                .totalVoteCount(50)
-                .reactivityScore(55) // 투표 50 + 댓글 5 = 반응성 55
+        Vote otherVote = Vote.builder()
+                .category(VoteCategory.LOVE).title("연애 밸런스 게임")
+                .totalVoteCount(50).reactivityScore(55)
                 .reactivityUpdatedAt(LocalDateTime.now())
-                .member(member2)
-                .pinType(PinType.NONE)//
-                .build();
+                .member(member2).pinType(PinType.NONE).build();
         voteRepository.save(otherVote);
 
-        CommentGroup commentGroup2 = CommentGroup.builder()
-                .vote(otherVote)
-                .totalCommentCount(5)
-                .build();
-        commentGroupRepository.save(commentGroup2);
+        commentGroupRepository.save(CommentGroup.builder()
+                .vote(otherVote).totalCommentCount(5).build());
     }
 
     @Test
     @DisplayName("반응성이 가장 높은 핫이슈 투표 정보를 성공적으로 조회한다.")
     void getHotIssueVote_Success() throws Exception {
-        mockMvc.perform(get("/votes/best") // GET 요청
-                        .contentType(MediaType.APPLICATION_JSON)) // 요청 타입
-                .andExpect(status().isOk()) // HTTP 상태 코드 200 OK 확인
-                .andExpect(jsonPath("$.voteId").isNumber()) // voteId가 숫자인지 확인
-                .andExpect(jsonPath("$.title").value("오늘의 점심 선택은?")) // 제목 확인 반응성 1위
-                .andExpect(jsonPath("$.category").value(VoteCategory.FOOD.name())) // 카테고리 확인
-                .andExpect(jsonPath("$.totalParticipants").value(100)) // 총 투표수 확인
-                .andExpect(jsonPath("$.createdBy").value("테스터1닉네임")) // 생성자 닉네임 확인
-                .andExpect(jsonPath("$.options[0].content").value("A. 맵고 얼큰한 라면")) // 첫 번째 옵션 내용 확인
-                .andExpect(jsonPath("$.options[0].vote_count").value(60)) // 첫 번째 옵션 투표 수 확인
-                .andExpect(jsonPath("$.options[1].content").value("B. 부드러운 파스타")) // 두 번째 옵션 내용 확인
-                .andExpect(jsonPath("$.options[1].vote_count").value(40)); // 두 번째 옵션 투표 수 확인
+        mockMvc.perform(get("/votes/best").contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.voteId").isNumber())
+                .andExpect(jsonPath("$.title").value("오늘의 점심 선택은?"))
+                .andExpect(jsonPath("$.category").value(VoteCategory.FOOD.name()))
+                .andExpect(jsonPath("$.totalParticipants").value(100))
+                .andExpect(jsonPath("$.createdBy").value("테스터1닉네임"))
+                .andExpect(jsonPath("$.options[0].content").value("A. 맵고 얼큰한 라면"))
+                .andExpect(jsonPath("$.options[0].vote_count").value(60))
+                .andExpect(jsonPath("$.options[1].content").value("B. 부드러운 파스타"))
+                .andExpect(jsonPath("$.options[1].vote_count").value(40));
     }
 
     @Test
     @DisplayName("핫이슈 투표가 없을 때 404 Not Found를 반환한다.")
     void getHotIssueVote_NotFound() throws Exception {
-        // 모든 투표 삭제하여 핫이슈 투표가 없는 상태로 만듦
         commentGroupRepository.deleteAll();
         voteRepository.deleteAll();
 
-        mockMvc.perform(get("/votes/best") // GET 요청
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isNotFound()) // HTTP 상태 코드 404 Not Found 확인
-                .andExpect(jsonPath("$.error").value("핫이슈 투표를 찾을 수 없습니다.")) // 에러 메시지 확인
-                .andExpect(jsonPath("$.status").value(404)) // 상태 코드 확인
-                .andExpect(jsonPath("$.type").value("ApiException")); // 예외 타입 확인
+        mockMvc.perform(get("/votes/best").contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error").value("핫이슈 투표를 찾을 수 없습니다."))
+                .andExpect(jsonPath("$.status").value(404));
+        // 참고: GlobalExceptionHandler에서 "type" 필드는 주석 처리되어 있음
     }
 
     @Test
     @DisplayName("동일한 반응성을 가진 투표 중 최신 투표를 조회한다.")
     void getHotIssueVote_SameTotalVoteCount_NewerIsHotIssue() throws Exception {
-        // 데이터 클린업
         commentGroupRepository.deleteAll();
         voteRepository.deleteAll();
 
-        // 멤버 생성
         Member member3 = Member.builder()
-                .socialId("kakao789")
-                .email("test3@example.com")
-                .name("테스터3")
+                .socialId("kakao789").email("test3@example.com").name("테스터3")
                 .profile_image_url("http://image.com/test3.jpg")
-                .kakaoAccessToken("token3")
-                .kakaoRefreshToken("refresh3")
-                .build();
+                .kakaoAccessToken("token3").kakaoRefreshToken("refresh3").build();
         memberRepository.save(member3);
 
-        MemberProfile profile3 = MemberProfile.builder()
-                .member(member3)
-                .nickname("테스터3닉네임")
-                .gender(Gender.MALE)
-                .age(Age.OVER_FORTY)
-                .mbti("INTP")
-                .build();
-        memberProfileRepository.save(profile3);
+        memberProfileRepository.save(MemberProfile.builder()
+                .member(member3).nickname("테스터3닉네임")
+                .gender(Gender.MALE).age(Age.OVER_FORTY).mbti("INTP").build());
 
-        // 오래된 투표 (반응성: 50)
         Vote oldVote = Vote.builder()
-                .category(VoteCategory.ETC)
-                .title("오래된 핫이슈 투표")
-                .totalVoteCount(50)
-                .reactivityScore(50) // 추가
-                .reactivityUpdatedAt(LocalDateTime.now().minusDays(3)) // 3일 전
-                .member(member3)
-                .pinType(PinType.NONE)
-                .build();
+                .category(VoteCategory.ETC).title("오래된 핫이슈 투표")
+                .totalVoteCount(50).reactivityScore(50)
+                .reactivityUpdatedAt(LocalDateTime.now().minusDays(3))
+                .member(member3).pinType(PinType.NONE).build();
         voteRepository.save(oldVote);
+        commentGroupRepository.save(CommentGroup.builder().vote(oldVote).totalCommentCount(0).build());
 
-        // CommentGroup 생성
-        CommentGroup commentGroup3 = CommentGroup.builder()
-                .vote(oldVote)
-                .totalCommentCount(0)
-                .build();
-        commentGroupRepository.save(commentGroup3);
-
-        // 새로운 투표 (동일한 반응성: 50, 하지만 더 최신)
         Vote newVote = Vote.builder()
-                .category(VoteCategory.LOVE)
-                .title("새로운 핫이슈 투표")
-                .totalVoteCount(50)
-                .reactivityScore(50) // 추가
-                .reactivityUpdatedAt(LocalDateTime.now()) // 현재 시간
-                .member(member3)
-                .pinType(PinType.NONE)
-                .build();
+                .category(VoteCategory.LOVE).title("새로운 핫이슈 투표")
+                .totalVoteCount(50).reactivityScore(50)
+                .reactivityUpdatedAt(LocalDateTime.now())
+                .member(member3).pinType(PinType.NONE).build();
         voteRepository.save(newVote);
+        commentGroupRepository.save(CommentGroup.builder().vote(newVote).totalCommentCount(0).build());
 
-        // CommentGroup 생성
-        CommentGroup commentGroup4 = CommentGroup.builder()
-                .vote(newVote)
-                .totalCommentCount(0)
-                .build();
-        commentGroupRepository.save(commentGroup4);
-
-        mockMvc.perform(get("/votes/best")
-                        .contentType(MediaType.APPLICATION_JSON))
+        mockMvc.perform(get("/votes/best").contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.title").value("새로운 핫이슈 투표")) // 최신 투표가 선택
+                .andExpect(jsonPath("$.title").value("새로운 핫이슈 투표"))
                 .andExpect(jsonPath("$.totalParticipants").value(50))
                 .andExpect(jsonPath("$.createdBy").value("테스터3닉네임"));
     }

--- a/src/test/java/com/valanse/valanse/service/CommentLikeService/CommentLikeServiceImplTest.java
+++ b/src/test/java/com/valanse/valanse/service/CommentLikeService/CommentLikeServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.valanse.valanse.service.CommentLikeService;
 
+import com.valanse.valanse.common.api.ApiException;
 import com.valanse.valanse.domain.Comment;
 import com.valanse.valanse.domain.Member;
 import com.valanse.valanse.domain.mapping.CommentLike;
@@ -8,6 +9,7 @@ import com.valanse.valanse.repository.CommentLikeRepository;
 import com.valanse.valanse.repository.CommentRepository;
 import com.valanse.valanse.repository.MemberRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -20,91 +22,82 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class CommentLikeServiceImplTest {
+
     @InjectMocks
     private CommentLikeServiceImpl commentLikeService;
 
-    @Mock
-    private CommentRepository commentRepository;
-    @Mock
-    private MemberRepository memberRepository;
-    @Mock
-    private CommentLikeRepository commentLikeRepository;
+    @Mock private CommentRepository commentRepository;
+    @Mock private MemberRepository memberRepository;
+    @Mock private CommentLikeRepository commentLikeRepository;
 
-    // Security에서 userId를 뽑아오기 때문에 미리 설정
     @BeforeEach
     void setupSecurityContext() {
-        Authentication authentication = mock(Authentication.class);
-        when(authentication.getName()).thenReturn("1"); // userId=1 가정
-        SecurityContext securityContext = mock(SecurityContext.class);
-        when(securityContext.getAuthentication()).thenReturn(authentication);
-        SecurityContextHolder.setContext(securityContext);
+        Authentication auth = mock(Authentication.class);
+        when(auth.getName()).thenReturn("1");
+        SecurityContext ctx = mock(SecurityContext.class);
+        when(ctx.getAuthentication()).thenReturn(auth);
+        SecurityContextHolder.setContext(ctx);
     }
 
-
     @Test
-    public void 좋아요_test() {
-        //given
+    @DisplayName("좋아요가 없는 댓글에 좋아요를 누르면 likeCount가 1 증가한다")
+    void 좋아요_성공() {
         Member member = new Member();
+        Comment comment = Comment.builder().content("댓글").likeCount(0).build();
+        CommentLike commentLike = CommentLike.builder().comment(comment).user(member).build();
 
-        Comment comment = Comment.builder()
-                .content("좋아요 없는 댓글")
-                .likeCount(0)
-                .build();
-
-        CommentLike commentLike = CommentLike.builder()
-                .comment(comment)
-                .user(member)
-                .build();
-        // stub
         when(memberRepository.findByIdAndDeletedAtIsNull(any())).thenReturn(Optional.of(member));
         when(commentRepository.findById(any())).thenReturn(Optional.of(comment));
-        // 첫번째 호출에서는 빈값, 두번째 호출에서는 commentLike 반환.
         when(commentLikeRepository.findByUserIdAndCommentId(any(), any()))
                 .thenReturn(Optional.empty())
                 .thenReturn(Optional.of(commentLike));
 
-        // when
-        CommentLikeResponseDto responseDto = commentLikeService.likeComment(1L, 1L);
+        CommentLikeResponseDto result = commentLikeService.likeComment(1L, 1L);
 
-        //then: 응답 dto 반환 값 확인
-        assertThat(responseDto.getLikeCount()).isEqualTo(1);
-        assertThat(responseDto.getMessage()).isEqualTo("좋아요 성공");
+        assertThat(result.getLikeCount()).isEqualTo(1);
+        assertThat(result.getMessage()).isEqualTo("좋아요 성공");
     }
 
     @Test
-    void 좋아요_취소_test() {
-        // when
+    @DisplayName("이미 좋아요를 누른 댓글에 다시 누르면 취소되고 likeCount가 감소한다")
+    void 좋아요_취소() {
         Member member = new Member();
+        Comment comment = Comment.builder().content("댓글").likeCount(1).build();
+        CommentLike commentLike = CommentLike.builder().comment(comment).user(member).build();
 
-        Comment comment = Comment.builder()
-                .content("좋아요 누른 댓글")
-                .likeCount(1)
-                .build();
-
-        CommentLike commentLike = CommentLike.builder()
-                .comment(comment)
-                .user(member)
-                .build();
-
-        // stub
         when(memberRepository.findByIdAndDeletedAtIsNull(any())).thenReturn(Optional.of(member));
         when(commentRepository.findById(any())).thenReturn(Optional.of(comment));
         when(commentLikeRepository.findByUserIdAndCommentId(any(), any()))
                 .thenReturn(Optional.of(commentLike))
                 .thenReturn(Optional.empty());
 
-        //when
-        CommentLikeResponseDto responseDto = commentLikeService.likeComment(1L, 1L);
+        CommentLikeResponseDto result = commentLikeService.likeComment(1L, 1L);
 
-        //then: 응답 dto 반환 값 확인
-        assertThat(responseDto.getLikeCount()).isEqualTo(0);
-        assertThat(responseDto.getMessage()).isEqualTo("좋아요 취소");
+        assertThat(result.getLikeCount()).isEqualTo(0);
+        assertThat(result.getMessage()).isEqualTo("좋아요 취소");
     }
-  
+
+    @Test
+    @DisplayName("존재하지 않는 회원이 좋아요를 시도하면 예외가 발생한다")
+    void 좋아요_존재하지않는회원() {
+        when(memberRepository.findByIdAndDeletedAtIsNull(any())).thenReturn(Optional.empty());
+
+        assertThrows(Exception.class, () -> commentLikeService.likeComment(1L, 1L));
+        verify(commentRepository, never()).findById(any());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 댓글에 좋아요를 시도하면 예외가 발생한다")
+    void 좋아요_존재하지않는댓글() {
+        when(memberRepository.findByIdAndDeletedAtIsNull(any())).thenReturn(Optional.of(new Member()));
+        when(commentRepository.findById(any())).thenReturn(Optional.empty());
+
+        assertThrows(Exception.class, () -> commentLikeService.likeComment(1L, 999L));
+    }
 }

--- a/src/test/java/com/valanse/valanse/service/ReportService/ReportServiceImplTest.java
+++ b/src/test/java/com/valanse/valanse/service/ReportService/ReportServiceImplTest.java
@@ -9,6 +9,7 @@ import com.valanse.valanse.domain.enums.ReportType;
 import com.valanse.valanse.repository.CommentRepository;
 import com.valanse.valanse.repository.ReportRepository;
 import com.valanse.valanse.repository.VoteRepository;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -21,114 +22,140 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class ReportServiceImplTest {
-    @InjectMocks
-    private ReportServiceImpl reportService;
 
-    @Mock
-    private ReportRepository reportRepository;
+    @InjectMocks private ReportServiceImpl reportService;
 
-    @Mock
-    private VoteRepository voteRepository;
+    @Mock private ReportRepository reportRepository;
+    @Mock private VoteRepository voteRepository;
+    @Mock private CommentRepository commentRepository;
 
-    @Mock
-    private CommentRepository commentRepository;
+    // ──────────────────────────────────────────────
+    // 정상 신고
+    // ──────────────────────────────────────────────
 
     @Test
-    void 댓글_신고() {
-        //given
-        Member member = Member.builder().id(1L).build();
+    @DisplayName("타인의 댓글을 신고하면 Report가 저장된다")
+    void 댓글_신고_성공() {
+        Member reporter = Member.builder().id(1L).build();
         Member writer = Member.builder().id(2L).build();
         Comment comment = Comment.builder().member(writer).build();
 
-        //stub
         when(commentRepository.findById(any())).thenReturn(Optional.of(comment));
         when(reportRepository.existsByMemberAndReportTypeAndTargetId(any(), any(), any())).thenReturn(false);
 
-        //when
-        reportService.report(member, 1L, ReportType.COMMENT);
+        reportService.report(reporter, 1L, ReportType.COMMENT);
 
-        //then
         ArgumentCaptor<Report> captor = ArgumentCaptor.forClass(Report.class);
         verify(reportRepository).save(captor.capture());
-        Report report = captor.getValue();
-        assertEquals(member, report.getMember());
+        assertThat(captor.getValue().getMember()).isEqualTo(reporter);
     }
 
     @Test
-    void 게임_신고() {
-        //given
-        Member member = Member.builder().id(1L).build();
+    @DisplayName("타인의 투표를 신고하면 Report가 저장된다")
+    void 게임_신고_성공() {
+        Member reporter = Member.builder().id(1L).build();
         Member writer = Member.builder().id(2L).build();
         Vote vote = Vote.builder().member(writer).build();
 
-        //stub
         when(voteRepository.findById(any())).thenReturn(Optional.of(vote));
         when(reportRepository.existsByMemberAndReportTypeAndTargetId(any(), any(), any())).thenReturn(false);
 
-        //when
-        reportService.report(member, 1L, ReportType.VOTE);
+        reportService.report(reporter, 1L, ReportType.VOTE);
 
-        //then
         ArgumentCaptor<Report> captor = ArgumentCaptor.forClass(Report.class);
         verify(reportRepository).save(captor.capture());
-        Report report = captor.getValue();
-        assertEquals(member, report.getMember());
+        assertThat(captor.getValue().getMember()).isEqualTo(reporter);
     }
 
+    // ──────────────────────────────────────────────
+    // 자기 자신 신고 불가
+    // ──────────────────────────────────────────────
+
     @Test
+    @DisplayName("본인 댓글은 신고할 수 없다")
     void 본인_댓글_신고_불가() {
-        //given
         Member writer = Member.builder().id(2L).build();
         Comment comment = Comment.builder().member(writer).build();
 
-        //stub
         when(commentRepository.findById(any())).thenReturn(Optional.of(comment));
 
-        //when
-        ApiException apiException = assertThrows(ApiException.class, () -> reportService.report(writer, 1L, ReportType.COMMENT));
-
-        //then
-        assertThat(apiException.getMessage()).isEqualTo("자신의 댓글은 신고할 수 없습니다.");
+        ApiException ex = assertThrows(ApiException.class,
+                () -> reportService.report(writer, 1L, ReportType.COMMENT));
+        assertThat(ex.getMessage()).isEqualTo("자신의 댓글은 신고할 수 없습니다.");
     }
 
     @Test
+    @DisplayName("본인 투표는 신고할 수 없다")
     void 본인_게임_신고_불가() {
-        //given
         Member writer = Member.builder().id(2L).build();
         Vote vote = Vote.builder().member(writer).build();
 
-        //stub
         when(voteRepository.findById(any())).thenReturn(Optional.of(vote));
 
-        //when
-        ApiException apiException = assertThrows(ApiException.class, () -> reportService.report(writer, 1L, ReportType.VOTE));
-
-        //then
-        assertThat(apiException.getMessage()).isEqualTo("자신의 투표는 신고할 수 없습니다.");
+        ApiException ex = assertThrows(ApiException.class,
+                () -> reportService.report(writer, 1L, ReportType.VOTE));
+        assertThat(ex.getMessage()).isEqualTo("자신의 투표는 신고할 수 없습니다.");
     }
 
+    // ──────────────────────────────────────────────
+    // 중복 신고 방지
+    // ──────────────────────────────────────────────
+
     @Test
+    @DisplayName("같은 댓글을 두 번 신고하면 예외가 발생한다")
     void 중복_신고_불가() {
-        //given
-        Member member = Member.builder().id(1L).build();
+        Member reporter = Member.builder().id(1L).build();
         Member writer = Member.builder().id(2L).build();
         Comment comment = Comment.builder().member(writer).build();
 
-        //stub
         when(commentRepository.findById(any())).thenReturn(Optional.of(comment));
         when(reportRepository.existsByMemberAndReportTypeAndTargetId(any(), any(), any())).thenReturn(true);
 
-        //when
-        ApiException apiException = assertThrows(ApiException.class, () -> reportService.report(member, 1L, ReportType.COMMENT));
-
-        //then
-        assertThat(apiException.getMessage()).isEqualTo("이미 신고한 대상입니다.");
+        ApiException ex = assertThrows(ApiException.class,
+                () -> reportService.report(reporter, 1L, ReportType.COMMENT));
+        assertThat(ex.getMessage()).isEqualTo("이미 신고한 대상입니다.");
     }
 
+    @Test
+    @DisplayName("같은 투표를 두 번 신고하면 예외가 발생한다")
+    void 중복_게임_신고_불가() {
+        Member reporter = Member.builder().id(1L).build();
+        Member writer = Member.builder().id(2L).build();
+        Vote vote = Vote.builder().member(writer).build();
 
+        when(voteRepository.findById(any())).thenReturn(Optional.of(vote));
+        when(reportRepository.existsByMemberAndReportTypeAndTargetId(any(), any(), any())).thenReturn(true);
+
+        ApiException ex = assertThrows(ApiException.class,
+                () -> reportService.report(reporter, 1L, ReportType.VOTE));
+        assertThat(ex.getMessage()).isEqualTo("이미 신고한 대상입니다.");
+    }
+
+    // ──────────────────────────────────────────────
+    // 존재하지 않는 대상 신고
+    // ──────────────────────────────────────────────
+
+    @Test
+    @DisplayName("존재하지 않는 댓글을 신고하면 예외가 발생한다")
+    void 존재하지않는_댓글_신고() {
+        Member reporter = Member.builder().id(1L).build();
+        when(commentRepository.findById(any())).thenReturn(Optional.empty());
+
+        assertThrows(Exception.class, () -> reportService.report(reporter, 999L, ReportType.COMMENT));
+        verify(reportRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 투표를 신고하면 예외가 발생한다")
+    void 존재하지않는_투표_신고() {
+        Member reporter = Member.builder().id(1L).build();
+        when(voteRepository.findById(any())).thenReturn(Optional.empty());
+
+        assertThrows(Exception.class, () -> reportService.report(reporter, 999L, ReportType.VOTE));
+        verify(reportRepository, never()).save(any());
+    }
 }

--- a/src/test/java/com/valanse/valanse/service/VoteService/VoteServiceImplTest.java
+++ b/src/test/java/com/valanse/valanse/service/VoteService/VoteServiceImplTest.java
@@ -5,13 +5,17 @@ import com.valanse.valanse.domain.CommentGroup;
 import com.valanse.valanse.domain.Member;
 import com.valanse.valanse.domain.Vote;
 import com.valanse.valanse.domain.VoteOption;
+import com.valanse.valanse.domain.enums.PinType;
 import com.valanse.valanse.domain.enums.Role;
 import com.valanse.valanse.domain.enums.VoteCategory;
+import com.valanse.valanse.domain.enums.VoteLabel;
 import com.valanse.valanse.domain.mapping.MemberVoteOption;
 import com.valanse.valanse.dto.Vote.VoteCancleResponseDto;
 import com.valanse.valanse.dto.Vote.VoteCreateRequest;
+import com.valanse.valanse.dto.Vote.VoteDetailResponse;
 import com.valanse.valanse.repository.*;
 import com.valanse.valanse.service.PointService.PointService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,6 +24,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.util.List;
 import java.util.Optional;
@@ -35,66 +42,83 @@ class VoteServiceImplTest {
     @InjectMocks
     private VoteServiceImpl voteService;
 
-    @Mock
-    private VoteRepository voteRepository;
-    @Mock
-    private MemberRepository memberRepository;
-    @Mock
-    private MemberVoteOptionRepository memberVoteOptionRepository;
-    @Mock
-    private CommentGroupRepository commentGroupRepository;
-    @Mock
-    private VoteOptionRepository voteOptionRepository;
-    @Mock
-    private PointService pointService;
+    @Mock private VoteRepository voteRepository;
+    @Mock private MemberRepository memberRepository;
+    @Mock private MemberVoteOptionRepository memberVoteOptionRepository;
+    @Mock private CommentGroupRepository commentGroupRepository;
+    @Mock private VoteOptionRepository voteOptionRepository;
+    @Mock private MemberProfileRepository memberProfileRepository;
+    @Mock private PointService pointService;
+
+    // ──────────────────────────────────────────────
+    // createVote
+    // ──────────────────────────────────────────────
 
     @Test
-    @DisplayName("투표 제목은 너무 길거나 너무 짧으면 안된다.")
-    void 제목길이실패_test() {
+    @DisplayName("투표 제목이 비어있으면 예외가 발생한다")
+    void 제목길이실패_빈제목() {
+        when(memberRepository.findByIdAndDeletedAtIsNull(any())).thenReturn(Optional.of(new Member()));
 
-        //given
-        Member member = new Member();
-        when(memberRepository.findByIdAndDeletedAtIsNull(any())).thenReturn(Optional.of(member));
+        VoteCreateRequest request = VoteCreateRequest.builder().title("").build();
 
-        // 주석 부분 바꿔가며 확인 가능
-        VoteCreateRequest request = VoteCreateRequest.builder()
-//                .title("123123123123123123123123123123")
-                .title("")
-                .build();
-
-        // when
-        ApiException exception = assertThrows(ApiException.class,
-                () -> voteService.createVote(1L, request));
-
-        // then
-        assertThat(exception.getMessage()).isEqualTo("투표 제목은 1자 이상 25자 이하여야 합니다 (공백 제외).");
+        ApiException ex = assertThrows(ApiException.class, () -> voteService.createVote(1L, request));
+        assertThat(ex.getMessage()).isEqualTo("투표 제목은 1자 이상 25자 이하여야 합니다 (공백 제외).");
+        assertThat(ex.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST);
     }
 
     @Test
-    @DisplayName("투표 옵션은 너무 많아도, 너무 적어도 안된다.")
-    void 투표옵션실패_test() {
-        // given
-        Member member = new Member();
-        when(memberRepository.findByIdAndDeletedAtIsNull(any())).thenReturn(Optional.of(member));
+    @DisplayName("공백만으로 된 제목은 비어있는 것으로 처리된다")
+    void 제목길이실패_공백만있는제목() {
+        when(memberRepository.findByIdAndDeletedAtIsNull(any())).thenReturn(Optional.of(new Member()));
 
-        // 주석 부분 바꿔가며 테스트 가능
-        VoteCreateRequest request = VoteCreateRequest.builder()
-                .title("테스트용 투표")
-//                .options(List.of("1번", "2번", "3번", "4번", "5번"))
-                .options(null)
-                .build();
-        // when
-        ApiException exception = assertThrows(ApiException.class,
-                () -> voteService.createVote(1L, request));
+        VoteCreateRequest request = VoteCreateRequest.builder().title("   ").build();
 
-        //then
-        assertThat(exception.getMessage()).isEqualTo("투표 옵션은 1개 이상 4개 이하여야 합니다.");
-        assertThat(exception.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST);
+        ApiException ex = assertThrows(ApiException.class, () -> voteService.createVote(1L, request));
+        assertThat(ex.getMessage()).isEqualTo("투표 제목은 1자 이상 25자 이하여야 합니다 (공백 제외).");
     }
 
     @Test
-    void 투표생성_test() {
-        // given
+    @DisplayName("투표 제목이 25자를 초과하면 예외가 발생한다")
+    void 제목길이실패_26자() {
+        when(memberRepository.findByIdAndDeletedAtIsNull(any())).thenReturn(Optional.of(new Member()));
+
+        VoteCreateRequest request = VoteCreateRequest.builder()
+                .title("123456789012345678901234567890") // 30자
+                .build();
+
+        ApiException ex = assertThrows(ApiException.class, () -> voteService.createVote(1L, request));
+        assertThat(ex.getMessage()).isEqualTo("투표 제목은 1자 이상 25자 이하여야 합니다 (공백 제외).");
+    }
+
+    @Test
+    @DisplayName("투표 옵션이 null이면 예외가 발생한다")
+    void 투표옵션실패_null() {
+        when(memberRepository.findByIdAndDeletedAtIsNull(any())).thenReturn(Optional.of(new Member()));
+
+        VoteCreateRequest request = VoteCreateRequest.builder()
+                .title("테스트 투표").options(null).build();
+
+        ApiException ex = assertThrows(ApiException.class, () -> voteService.createVote(1L, request));
+        assertThat(ex.getMessage()).isEqualTo("투표 옵션은 1개 이상 4개 이하여야 합니다.");
+    }
+
+    @Test
+    @DisplayName("투표 옵션이 5개 이상이면 예외가 발생한다")
+    void 투표옵션실패_5개() {
+        when(memberRepository.findByIdAndDeletedAtIsNull(any())).thenReturn(Optional.of(new Member()));
+
+        VoteCreateRequest request = VoteCreateRequest.builder()
+                .title("테스트 투표")
+                .options(List.of("1", "2", "3", "4", "5"))
+                .build();
+
+        ApiException ex = assertThrows(ApiException.class, () -> voteService.createVote(1L, request));
+        assertThat(ex.getMessage()).isEqualTo("투표 옵션은 1개 이상 4개 이하여야 합니다.");
+    }
+
+    @Test
+    @DisplayName("투표 생성 시 voteRepository, commentGroupRepository, pointService가 각 1회 호출된다")
+    void 투표생성_성공() {
         Member member = new Member();
 
         VoteCreateRequest request = VoteCreateRequest.builder()
@@ -103,214 +127,292 @@ class VoteServiceImplTest {
                 .category(VoteCategory.ALL)
                 .build();
 
-        Vote vote = Vote.builder()
-                .id(100L)
-                .title(request.getTitle())
-                .content(request.getContent())
-                .category(request.getCategory())
-                .member(member)
-                .build();
+        Vote savedVote = Vote.builder()
+                .id(100L).title(request.getTitle())
+                .category(request.getCategory()).member(member).build();
 
-        //stub
         when(memberRepository.findByIdAndDeletedAtIsNull(any())).thenReturn(Optional.of(member));
-        when(voteRepository.save(any())).thenReturn(vote);
+        when(voteRepository.save(any())).thenReturn(savedVote);
 
-        // when
         Long voteId = voteService.createVote(1L, request);
 
-        // then
         assertThat(voteId).isEqualTo(100L);
 
-        verify(voteRepository).save(any(Vote.class));
-        verify(commentGroupRepository).save(any(CommentGroup.class));
+        ArgumentCaptor<Vote> voteCaptor = ArgumentCaptor.forClass(Vote.class);
+        verify(voteRepository).save(voteCaptor.capture());
+        assertThat(voteCaptor.getValue().getVoteOptions()).hasSize(4);
 
-        ArgumentCaptor<Vote> voteArgumentCaptor = ArgumentCaptor.forClass(Vote.class);
-        verify(voteRepository).save(voteArgumentCaptor.capture());
-        Vote captorVote = voteArgumentCaptor.getValue();
-        assertThat(captorVote.getVoteOptions()).hasSize(4);
+        verify(commentGroupRepository).save(any(CommentGroup.class));
+        verify(pointService, times(1)).givePoint(any(), any());
     }
 
+    // ──────────────────────────────────────────────
+    // processVote
+    // ──────────────────────────────────────────────
+
     @Test
-    void 처음투표하기_test() {
-        // given
-        Member member = Member.builder()
-                .id(1L)
-                .build();
-        Vote vote = Vote.builder()
-                .id(10L)
-                .totalVoteCount(7)
-                .build();
+    @DisplayName("처음 투표 시 카운트가 증가하고 isVoted=true를 반환한다")
+    void 처음투표하기() {
+        Member member = Member.builder().id(1L).build();
+        Member postOwner = Member.builder().id(99L).build();
+        Vote vote = Vote.builder().id(10L).totalVoteCount(7).member(postOwner).build();
+        VoteOption voteOption = VoteOption.builder().id(100L).voteCount(3).vote(vote).build();
 
-        VoteOption voteOption = VoteOption.builder()
-                .id(100L)
-                .voteCount(3)
-                .vote(vote)
-                .build();
-
-
-        // stub
         when(memberRepository.findByIdAndDeletedAtIsNull(any())).thenReturn(Optional.of(member));
         when(voteRepository.findById(any())).thenReturn(Optional.of(vote));
         when(voteOptionRepository.findById(any())).thenReturn(Optional.of(voteOption));
         when(memberVoteOptionRepository.findByMemberIdAndVoteId(any(), any())).thenReturn(Optional.empty());
 
-        // when
-        VoteCancleResponseDto responseDto = voteService.processVote(1L, 10L, 100L);
+        VoteCancleResponseDto result = voteService.processVote(1L, 10L, 100L);
 
-        // then : 응답 dto 속성 검증
-        assertThat(responseDto.getTotalVoteCount()).isEqualTo(8);
-        assertThat(responseDto.getVoteOptionCount()).isEqualTo(4);
-        assertThat(responseDto.isVoted()).isTrue();
+        assertThat(result.getTotalVoteCount()).isEqualTo(8);
+        assertThat(result.getVoteOptionCount()).isEqualTo(4);
+        assertThat(result.isVoted()).isTrue();
     }
 
     @Test
-    void 투표취소_test() {
+    @DisplayName("처음 투표 시 본인 게시물이 아니면 작성자에게 포인트가 지급된다")
+    void 처음투표_포인트지급() {
+        Member voter = Member.builder().id(1L).build();
+        Member postOwner = Member.builder().id(99L).build();
+        Vote vote = Vote.builder().id(10L).totalVoteCount(0).member(postOwner).build();
+        VoteOption option = VoteOption.builder().id(100L).voteCount(0).vote(vote).build();
 
-        // given
-        Member member = Member.builder()
-                .id(1L)
-                .build();
+        when(memberRepository.findByIdAndDeletedAtIsNull(any())).thenReturn(Optional.of(voter));
+        when(voteRepository.findById(any())).thenReturn(Optional.of(vote));
+        when(voteOptionRepository.findById(any())).thenReturn(Optional.of(option));
+        when(memberVoteOptionRepository.findByMemberIdAndVoteId(any(), any())).thenReturn(Optional.empty());
 
-        Vote vote = Vote.builder()
-                .id(10L)
-                .totalVoteCount(7)
-                .build();
+        voteService.processVote(1L, 10L, 100L);
 
-        VoteOption voteOption = VoteOption.builder()
-                .id(100L)
-                .voteCount(3)
-                .vote(vote)
-                .build();
+        verify(pointService, times(1)).givePoint(eq(99L), any());
+    }
 
-        MemberVoteOption mvo = MemberVoteOption.builder()
-                .voteOption(voteOption)
-                .build();
-        //stub
+    @Test
+    @DisplayName("본인 게시물에 투표해도 포인트가 지급되지 않는다")
+    void 처음투표_본인게시물_포인트미지급() {
+        Member member = Member.builder().id(1L).build();
+        Vote vote = Vote.builder().id(10L).totalVoteCount(0).member(member).build(); // 본인 게시물
+        VoteOption option = VoteOption.builder().id(100L).voteCount(0).vote(vote).build();
+
+        when(memberRepository.findByIdAndDeletedAtIsNull(any())).thenReturn(Optional.of(member));
+        when(voteRepository.findById(any())).thenReturn(Optional.of(vote));
+        when(voteOptionRepository.findById(any())).thenReturn(Optional.of(option));
+        when(memberVoteOptionRepository.findByMemberIdAndVoteId(any(), any())).thenReturn(Optional.empty());
+
+        voteService.processVote(1L, 10L, 100L);
+
+        verify(pointService, never()).givePoint(any(), any());
+    }
+
+    @Test
+    @DisplayName("동일 선택지를 다시 클릭하면 투표가 취소되고 카운트가 감소한다")
+    void 투표취소() {
+        Member member = Member.builder().id(1L).build();
+        Vote vote = Vote.builder().id(10L).totalVoteCount(7).build();
+        VoteOption voteOption = VoteOption.builder().id(100L).voteCount(3).vote(vote).build();
+        MemberVoteOption mvo = MemberVoteOption.builder().voteOption(voteOption).build();
+
         when(memberRepository.findByIdAndDeletedAtIsNull(any())).thenReturn(Optional.of(member));
         when(voteRepository.findById(any())).thenReturn(Optional.of(vote));
         when(voteOptionRepository.findById(any())).thenReturn(Optional.of(voteOption));
         when(memberVoteOptionRepository.findByMemberIdAndVoteId(any(), any())).thenReturn(Optional.of(mvo));
 
-        //when
-        VoteCancleResponseDto responseDto = voteService.processVote(1L, 10L, 100L);
+        VoteCancleResponseDto result = voteService.processVote(1L, 10L, 100L);
 
-        //then: dto 값 검증, memberVoteOption 삭제 호출 1회 검증
-        assertThat(responseDto.getTotalVoteCount()).isEqualTo(6);
-        assertThat(responseDto.getVoteOptionCount()).isEqualTo(2);
-        assertThat(responseDto.isVoted()).isFalse();
-
-        verify(memberVoteOptionRepository,times(1)).delete(any(MemberVoteOption.class));
+        assertThat(result.getTotalVoteCount()).isEqualTo(6);
+        assertThat(result.getVoteOptionCount()).isEqualTo(2);
+        assertThat(result.isVoted()).isFalse();
+        verify(memberVoteOptionRepository, times(1)).delete(any(MemberVoteOption.class));
     }
 
     @Test
-    void 투표재선택_test(){
+    @DisplayName("다른 선택지로 재선택하면 기존 카운트가 감소하고 새 카운트가 증가한다")
+    void 투표재선택() {
+        Member member = Member.builder().id(1L).build();
+        Vote vote = Vote.builder().id(10L).totalVoteCount(7).build();
+        VoteOption oldOption = VoteOption.builder().id(100L).voteCount(3).vote(vote).build();
+        VoteOption newOption = VoteOption.builder().id(101L).voteCount(10).vote(vote).build();
+        MemberVoteOption mvo = MemberVoteOption.builder().voteOption(oldOption).build();
 
-        // given
-        Member member = Member.builder()
-                .id(1L)
-                .build();
-        Vote vote = Vote.builder()
-                .id(10L)
-                .totalVoteCount(7)
-                .build();
-
-        VoteOption voteOption = VoteOption.builder()
-                .id(100L)
-                .voteCount(3)
-                .vote(vote)
-                .build();
-        VoteOption newVoteOption = VoteOption.builder()
-                .id(101L)
-                .voteCount(10)
-                .vote(vote)
-                .build();
-
-        MemberVoteOption mvo = MemberVoteOption.builder()
-                .voteOption(voteOption)
-                .build();
-        //stub
         when(memberRepository.findByIdAndDeletedAtIsNull(any())).thenReturn(Optional.of(member));
         when(voteRepository.findById(any())).thenReturn(Optional.of(vote));
-        when(voteOptionRepository.findById(any())).thenReturn(Optional.of(newVoteOption));
+        when(voteOptionRepository.findById(any())).thenReturn(Optional.of(newOption));
         when(memberVoteOptionRepository.findByMemberIdAndVoteId(any(), any())).thenReturn(Optional.of(mvo));
 
-        //when
-        VoteCancleResponseDto responseDto = voteService.processVote(1L, 10L, 101L);
+        VoteCancleResponseDto result = voteService.processVote(1L, 10L, 101L);
 
-        //then: repository 동작, 응답 dto 속성 검증
-        assertThat(responseDto.getTotalVoteCount()).isEqualTo(7);
-        assertThat(responseDto.getVoteOptionCount()).isEqualTo(11);
-        assertThat(responseDto.isVoted()).isTrue();
-
+        assertThat(result.getTotalVoteCount()).isEqualTo(7); // 총 투표 수 변동 없음
+        assertThat(result.getVoteOptionCount()).isEqualTo(11); // 새 옵션 +1
+        assertThat(result.isVoted()).isTrue();
+        assertThat(oldOption.getVoteCount()).isEqualTo(2); // 기존 옵션 -1
         verify(memberVoteOptionRepository, times(1)).delete(any(MemberVoteOption.class));
         verify(memberVoteOptionRepository, times(1)).save(any(MemberVoteOption.class));
-        verify(voteOptionRepository, times(2)).save(any(VoteOption.class));
+    }
+
+    // ──────────────────────────────────────────────
+    // getVoteDetailById
+    // ──────────────────────────────────────────────
+
+    @Test
+    @DisplayName("존재하지 않는 투표 ID 조회 시 404 예외가 발생한다")
+    void 투표상세조회_없는ID() {
+        when(voteRepository.findById(any())).thenReturn(Optional.empty());
+
+        ApiException ex = assertThrows(ApiException.class, () -> voteService.getVoteDetailById(999L));
+        assertThat(ex.getMessage()).isEqualTo("투표를 찾을 수 없습니다.");
+        assertThat(ex.getStatus()).isEqualTo(HttpStatus.NOT_FOUND);
     }
 
     @Test
-    @DisplayName("관리자의 권한으로 다른 사용자의 투표를 삭제한다.")
-    void 관리자권한_투표삭제_test() {
-        //given
-        Member admin = Member.builder()
-                .id(1L)
-                .role(Role.ADMIN)
-                .build();
+    @DisplayName("비로그인 사용자는 hasVoted=false로 투표 상세를 조회할 수 있다")
+    void 투표상세조회_비로그인() {
+        // SecurityContext를 익명 사용자로 설정
+        Authentication auth = mock(Authentication.class);
+        when(auth.getName()).thenReturn("anonymousUser");
+        SecurityContext ctx = mock(SecurityContext.class);
+        when(ctx.getAuthentication()).thenReturn(auth);
+        SecurityContextHolder.setContext(ctx);
 
-        Member member = Member.builder()
-                .id(2L)
-                .build();
-
+        VoteOption option = VoteOption.builder()
+                .id(1L).content("A선택지").voteCount(5).label(VoteLabel.A).build();
         Vote vote = Vote.builder()
-                .member(member)
-                .id(10L)
-                .totalVoteCount(7)
-                .build();
+                .id(10L).title("테스트 투표").totalVoteCount(10).build();
+        vote.addVoteOption(option);
 
-        //stub
-        when(memberRepository.findByIdAndDeletedAtIsNull(any())).thenReturn(Optional.of(admin));
-        when(voteRepository.findById(any())).thenReturn(Optional.of(vote));
+        when(voteRepository.findById(10L)).thenReturn(Optional.of(vote));
 
-        //when
-        voteService.deleteVote(1L,10L);
+        VoteDetailResponse result = voteService.getVoteDetailById(10L);
 
-        //then
-        ArgumentCaptor<Vote> voteArgumentCaptor = ArgumentCaptor.forClass(Vote.class);
-        verify(voteRepository).save(voteArgumentCaptor.capture());
-        Vote captorVote = voteArgumentCaptor.getValue();
-        assertThat((captorVote.getDeletedAt())).isNotNull();
+        assertThat(result.getHasVoted()).isFalse();
+        assertThat(result.getVotedOptionLabel()).isNull();
+        assertThat(result.getOptions()).hasSize(1);
     }
 
     @Test
-    @DisplayName("관리자가 아니면 다른 사용자의 투표를 삭제할 수 없다.")
-    void 관리자_투표삭제_실패test() {
-        //given
-        Member admin = Member.builder()
-                .id(1L)
-                .role(Role.USER)
-                .build();
+    @DisplayName("로그인 사용자가 투표한 경우 hasVoted=true와 선택지 라벨을 반환한다")
+    void 투표상세조회_이미투표한경우() {
+        Authentication auth = mock(Authentication.class);
+        when(auth.getName()).thenReturn("1");
+        SecurityContext ctx = mock(SecurityContext.class);
+        when(ctx.getAuthentication()).thenReturn(auth);
+        SecurityContextHolder.setContext(ctx);
 
-        Member member = Member.builder()
-                .id(2L)
-                .build();
-
+        VoteOption option = VoteOption.builder()
+                .id(100L).content("A선택지").voteCount(5).label(VoteLabel.A).build();
         Vote vote = Vote.builder()
-                .member(member)
-                .id(10L)
-                .totalVoteCount(7)
-                .build();
-        // stub
-        when(memberRepository.findByIdAndDeletedAtIsNull(any())).thenReturn(Optional.of(admin));
-        when(voteRepository.findById(any())).thenReturn(Optional.of(vote));
+                .id(10L).title("테스트 투표").totalVoteCount(10).build();
+        vote.addVoteOption(option);
 
-        // when
-        ApiException apiException = assertThrows(ApiException.class, () -> voteService.deleteVote(1L, 10L));
+        MemberVoteOption mvo = MemberVoteOption.builder().voteOption(option).build();
 
-        // then
-        assertThat(apiException.getMessage()).isEqualTo("삭제 권한이 없습니다.");
+        when(voteRepository.findById(10L)).thenReturn(Optional.of(vote));
+        when(memberVoteOptionRepository.findByMemberIdAndVoteId(1L, 10L)).thenReturn(Optional.of(mvo));
+
+        VoteDetailResponse result = voteService.getVoteDetailById(10L);
+
+        assertThat(result.getHasVoted()).isTrue();
+        assertThat(result.getVotedOptionLabel()).isEqualTo("A");
     }
 
+    // ──────────────────────────────────────────────
+    // deleteVote
+    // ──────────────────────────────────────────────
 
+    @Test
+    @DisplayName("본인이 만든 투표를 삭제하면 softDelete가 적용된다")
+    void 본인_투표삭제_성공() {
+        Member member = Member.builder().id(1L).role(Role.USER).build();
+        Vote vote = Vote.builder().id(10L).member(member).build();
 
+        when(voteRepository.findById(any())).thenReturn(Optional.of(vote));
+        when(memberRepository.findByIdAndDeletedAtIsNull(any())).thenReturn(Optional.of(member));
 
+        voteService.deleteVote(1L, 10L);
 
+        ArgumentCaptor<Vote> captor = ArgumentCaptor.forClass(Vote.class);
+        verify(voteRepository).save(captor.capture());
+        assertThat(captor.getValue().getDeletedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("관리자는 다른 사용자의 투표를 삭제할 수 있다")
+    void 관리자_타인투표_삭제성공() {
+        Member admin = Member.builder().id(1L).role(Role.ADMIN).build();
+        Member writer = Member.builder().id(2L).role(Role.USER).build();
+        Vote vote = Vote.builder().id(10L).member(writer).build();
+
+        when(voteRepository.findById(any())).thenReturn(Optional.of(vote));
+        when(memberRepository.findByIdAndDeletedAtIsNull(any())).thenReturn(Optional.of(admin));
+
+        voteService.deleteVote(1L, 10L);
+
+        ArgumentCaptor<Vote> captor = ArgumentCaptor.forClass(Vote.class);
+        verify(voteRepository).save(captor.capture());
+        assertThat(captor.getValue().getDeletedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("일반 사용자가 다른 사람의 투표를 삭제하려 하면 403 예외가 발생한다")
+    void 일반사용자_타인투표_삭제실패() {
+        Member user = Member.builder().id(1L).role(Role.USER).build();
+        Member writer = Member.builder().id(2L).role(Role.USER).build();
+        Vote vote = Vote.builder().id(10L).member(writer).build();
+
+        when(voteRepository.findById(any())).thenReturn(Optional.of(vote));
+        when(memberRepository.findByIdAndDeletedAtIsNull(any())).thenReturn(Optional.of(user));
+
+        ApiException ex = assertThrows(ApiException.class, () -> voteService.deleteVote(1L, 10L));
+        assertThat(ex.getMessage()).isEqualTo("삭제 권한이 없습니다.");
+        assertThat(ex.getStatus()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    // ──────────────────────────────────────────────
+    // updatePinStatus
+    // ──────────────────────────────────────────────
+
+    @Test
+    @DisplayName("일반 사용자가 핀 설정을 시도하면 403 예외가 발생한다")
+    void 핀설정_권한없음() {
+        Member user = Member.builder().id(1L).role(Role.USER).build();
+
+        ApiException ex = assertThrows(ApiException.class,
+                () -> voteService.updatePinStatus(user, 10L, PinType.HOT));
+        assertThat(ex.getMessage()).isEqualTo("권한이 없습니다.");
+        assertThat(ex.getStatus()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("관리자가 HOT 핀 설정 시 기존 HOT 게시물의 핀이 해제된다")
+    void 핀설정_기존핀해제() {
+        Member admin = Member.builder().id(1L).role(Role.ADMIN).build();
+
+        Vote existingHot = Vote.builder().id(99L).build();
+        existingHot.pin(PinType.HOT);
+        Vote newVote = Vote.builder().id(10L).build();
+
+        when(voteRepository.findById(10L)).thenReturn(Optional.of(newVote));
+        when(voteRepository.findByPinType(PinType.HOT)).thenReturn(Optional.of(existingHot));
+
+        voteService.updatePinStatus(admin, 10L, PinType.HOT);
+
+        assertThat(existingHot.getPinType()).isEqualTo(PinType.NONE); // 기존 게시물 핀 해제
+        assertThat(newVote.getPinType()).isEqualTo(PinType.HOT);      // 새 게시물 핀 설정
+        verify(voteRepository, times(2)).save(any(Vote.class));
+    }
+
+    @Test
+    @DisplayName("관리자가 NONE으로 설정하면 핀이 해제된다")
+    void 핀해제() {
+        Member admin = Member.builder().id(1L).role(Role.ADMIN).build();
+        Vote vote = Vote.builder().id(10L).build();
+        vote.pin(PinType.HOT);
+
+        when(voteRepository.findById(10L)).thenReturn(Optional.of(vote));
+
+        voteService.updatePinStatus(admin, 10L, PinType.NONE);
+
+        assertThat(vote.getPinType()).isEqualTo(PinType.NONE);
+        verify(voteRepository, times(1)).save(vote);
+    }
 }


### PR DESCRIPTION
## 작업 내용

### 🔧 N+1 쿼리 제거
- `getHotIssueVote()`, `getTrendingVote()`에서 `findAll()` 후 루프로 `save()`하던 패턴 제거
- `VoteRepositoryCustom`에 `findHotIssueVote()`, `findTrendingVote()` 추가
- QueryDSL `LEFT JOIN` + `COALESCE`로 단일 쿼리로 개선
  - 정렬 기준: `totalVoteCount + commentGroup.totalCommentCount` (점수 동일 시 최신순)

### 🧹 코드 품질 개선
- `getVoteDetailById()` 내 `System.out.println` 디버그 로그 3개 제거
- `getTrendingVote()` 불필요한 `@Transactional` 제거 (데이터 변경 없음)
- `processVote()` 내 `[cite: image_...]` 잔존 주석 제거

### ✅ 테스트 케이스 보강
- `VoteServiceImplTest`: 9개 → 17개
  - 공백/초과 제목 검증, 처음 투표 시 포인트 지급/미지급
  - `getVoteDetailById` 비로그인/투표완료 케이스
  - `updatePinStatus` 권한없음/기존핀해제/핀해제
- `ReportServiceImplTest`: 5개 → 7개
  - 중복 신고, 존재하지 않는 대상 신고
- `CommentLikeServiceImplTest`: 2개 → 4개
  - 존재하지 않는 회원/댓글 좋아요 시도
- `VoteControllerTest`: `GlobalExceptionHandler` 응답 형식에 맞게 `$.type` 검증 제거

## 변경 파일
- `VoteRepositoryCustom.java` — 인터페이스 메서드 2개 추가
- `VoteRepositoryImpl.java` — QueryDSL 구현체 추가
- `VoteServiceImpl.java` — N+1 제거, 로그/주석 정리
- `VoteServiceImplTest.java`, `ReportServiceImplTest.java`, `CommentLikeServiceImplTest.java`, `VoteControllerTest.java` — 테스트 보강