### PR TITLE
fix:투표 업로드 두가지 방식 모두 지원

### DIFF
--- a/src/main/java/com/valanse/valanse/dto/Vote/VoteCreateRequest.java
+++ b/src/main/java/com/valanse/valanse/dto/Vote/VoteCreateRequest.java
@@ -1,6 +1,8 @@
 package com.valanse.valanse.dto.Vote;// src/main/java/com/valanse/valanse/dto/vote/VoteCreateRequest.java
 
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.valanse.valanse.domain.enums.VoteCategory;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -30,5 +32,29 @@ public class VoteCreateRequest {
         private String key;
         private String content;
         private String imageKey;
+
+        /**
+         * 구형 문자열 옵션과 이미지 업로드용 객체 옵션을 모두 지원합니다.
+         */
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        public OptionRequest(JsonNode value) {
+            if (value.isTextual()) {
+                this.content = value.textValue();
+                return;
+            }
+
+            if (!value.isObject()) {
+                throw new IllegalArgumentException("투표 옵션은 문자열 또는 객체여야 합니다.");
+            }
+
+            this.key = nullableText(value, "key");
+            this.content = nullableText(value, "content");
+            this.imageKey = nullableText(value, "imageKey");
+        }
+
+        private static String nullableText(JsonNode object, String fieldName) {
+            JsonNode field = object.get(fieldName);
+            return field == null || field.isNull() ? null : field.asText();
+        }
     }
 }

--- a/src/test/java/com/valanse/valanse/dto/Vote/VoteCreateRequestTest.java
+++ b/src/test/java/com/valanse/valanse/dto/Vote/VoteCreateRequestTest.java
@@ -1,0 +1,56 @@
+package com.valanse.valanse.dto.Vote;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class VoteCreateRequestTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void 구형_문자열_옵션_배열을_역직렬화한다() throws Exception {
+        String json = """
+                {
+                  "title": "가격 선택",
+                  "content": "설명",
+                  "options": ["500", "1000"],
+                  "category": "BUY"
+                }
+                """;
+
+        VoteCreateRequest request = objectMapper.readValue(json, VoteCreateRequest.class);
+
+        assertThat(request.getOptions())
+                .extracting(VoteCreateRequest.OptionRequest::getContent)
+                .containsExactly("500", "1000");
+        assertThat(request.getOptions())
+                .extracting(VoteCreateRequest.OptionRequest::getImageKey)
+                .containsOnlyNulls();
+    }
+
+    @Test
+    void 이미지용_객체_옵션_배열을_역직렬화한다() throws Exception {
+        String json = """
+                {
+                  "title": "이미지 선택",
+                  "options": [
+                    {
+                      "key": "A",
+                      "content": "첫 번째",
+                      "imageKey": "option-a-image"
+                    }
+                  ],
+                  "category": "ETC"
+                }
+                """;
+
+        VoteCreateRequest request = objectMapper.readValue(json, VoteCreateRequest.class);
+        VoteCreateRequest.OptionRequest option = request.getOptions().get(0);
+
+        assertThat(option.getKey()).isEqualTo("A");
+        assertThat(option.getContent()).isEqualTo("첫 번째");
+        assertThat(option.getImageKey()).isEqualTo("option-a-image");
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 투표 생성 요청에서 옵션 입력을 문자열과 객체 형식 모두 지원하도록 개선했습니다.
  * 문자열로 입력된 옵션은 기존 값이 그대로 반영되고, 객체로 입력된 옵션은 키·내용·이미지 정보가 정상 처리됩니다.
  * 잘못된 형식의 옵션 입력은 명확하게 거부되도록 검증이 강화되었습니다.

* **Tests**
  * 문자열/객체 형태의 옵션 입력에 대한 역직렬화 동작을 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->